### PR TITLE
Fixed bug when resolving a project root directory when there's no global.json file.

### DIFF
--- a/src/Microsoft.Dnx.Watcher.Core/FileSystem/FileWatcher.cs
+++ b/src/Microsoft.Dnx.Watcher.Core/FileSystem/FileWatcher.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Dnx.Watcher.Core
             }
 
             // If we don't find any files then make the project folder the root
-            return projectPath;
+            return Path.GetDirectoryName(projectPath);
         }
     }
 }


### PR DESCRIPTION
### Environment

* **Operating system:** Windows 7 Enterprise 64-bit.
* **Node:** v4.2.2
* **yo:** 1.5.0
* **generator-aspnet:** 0.0.90
* **.NET environment:** 1.0.0-rc1-final coreclr x64 win
* **dnx-watch:** 1.0.0-rc1-final

### Steps to reproduce

* Create a test directory and restore packages
```cmd
mkdir test
cd test
```
* Create a class library
```cmd
yo aspnet
cd ClassLibrary
dnu restore
cd ..
```

* Edit ```~/test/ConsoleApplication/project.json``` as follows:

```json
{
  (...)

  "dependencies": {
    "ClassLibrary": ""
  },

  (...)
}
```

* Restore packages.

```cmd
dnu restore
```

* Attempt to run ```dnx-watch```

```cmd
dnx-watch run
```

* You will get an error similar to the following:

```
System.ArgumentException: The directory name C:\test\ClassLibrary\project.json is invalid.
Parameter name: path
   at System.IO.FileSystemWatcher..ctor(String path, String filter)
   at Microsoft.Dnx.Watcher.Core.FileWatcher.AddWatcher(String path)
   at Microsoft.Dnx.Watcher.Core.DnxWatcher.AddProjectAndDependeciesToWatcher(IProject project, IFileWatcher fileWatcher)
   at Microsoft.Dnx.Watcher.Core.DnxWatcher.AddProjectAndDependeciesToWatcher(IProject project, IFileWatcher fileWatcher)
   at Microsoft.Dnx.Watcher.Core.DnxWatcher.<WaitForProjectFileToChangeAsync>d__7.MoveNext()
```

* Create a ```~/test/global.json``` file:

```json
{
  "projects": [
    "ClassLibrary",
    "ConsoleApplication"
  ]
}
```

* Attempt to run ```dnx-watch``` again.